### PR TITLE
Add disable feature to fall back to log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.6] - 2022-08-22
+- `std-log` feature to use normal logging for testing etc. @robin-nitrokey
+
 ## [0.1.5]- 2022-06-25
 - fix incorrect MIT license copyright info
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ insta = "1.7"
 example = ["std"]
 # sole reason for this is to enable `print!` in the example's `Std{err,out}Flusher`
 std = []
+# disable deferred logging and use log::log instead
+disable = []
 
 max_level_off   = ["log/max_level_off"]
 max_level_error = ["log/max_level_error"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "delog"
-version = "0.1.5"
+version = "0.1.6"
 description = "Deferred logging, an implementation and extension of Rust's standard logging facade."
 authors = ["Trussed Developers"]
 license = "Apache-2.0 OR MIT"
@@ -25,8 +25,8 @@ insta = "1.7"
 example = ["std"]
 # sole reason for this is to enable `print!` in the example's `Std{err,out}Flusher`
 std = []
-# disable deferred logging and use log::log instead
-disable = []
+# replace deferred logging with log::log
+std-log = []
 
 max_level_off   = ["log/max_level_off"]
 max_level_error = ["log/max_level_error"]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,6 +1,7 @@
 /// Fallible (ungated) version of `log!`.
 #[macro_export]
 #[doc(hidden)]
+#[cfg(not(feature = "disable"))]
 macro_rules! try_log {
 
     (target: $target:expr, $lvl:expr, $message:expr) => ({
@@ -32,6 +33,27 @@ macro_rules! try_log {
     });
 
     ($lvl:expr, $($arg:tt)+) => ($crate::try_log!(target: $crate::log::__log_module_path!(), $lvl, $($arg)+))
+}
+
+#[macro_export]
+#[doc(hidden)]
+#[cfg(feature = "disable")]
+macro_rules! try_log {
+
+    (target: $target:expr, $lvl:expr, $message:expr) => ({
+        $crate::log::log!(target: $target, $lvl, $message);
+        ::core::result::Result::<(), ()>::Ok(())
+    });
+
+    (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        $crate::log::log!(target: $target, $lvl, $($arg)+);
+        ::core::result::Result::<(), ()>::Ok(())
+    });
+
+    ($lvl:expr, $($arg:tt)+) => ({
+        $crate::log::log!($lvl, $($arg)+);
+        ::core::result::Result::<(), ()>::Ok(())
+    });
 }
 
 // There is a syntax issue with "repetitions in binding patterns for nested macros",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,7 +1,7 @@
 /// Fallible (ungated) version of `log!`.
 #[macro_export]
 #[doc(hidden)]
-#[cfg(not(feature = "disable"))]
+#[cfg(not(feature = "std-log"))]
 macro_rules! try_log {
 
     (target: $target:expr, $lvl:expr, $message:expr) => ({
@@ -37,7 +37,7 @@ macro_rules! try_log {
 
 #[macro_export]
 #[doc(hidden)]
-#[cfg(feature = "disable")]
+#[cfg(feature = "std-log")]
 macro_rules! try_log {
 
     (target: $target:expr, $lvl:expr, $message:expr) => ({


### PR DESCRIPTION
This patch adds a disable feature that replaces the deferred logging
infrastructure with log’s upstream logging mechanism.  This makes it
possible to use other logger implementations in unit tests and
simulations.