### PR TITLE
StderrFlusher actually prints to stderr

### DIFF
--- a/src/example.rs
+++ b/src/example.rs
@@ -33,7 +33,7 @@ pub struct StderrFlusher {}
 
 impl crate::Flusher for StderrFlusher {
     fn flush(&self, logs: &str) {
-        print!("{}", logs);
+        eprint!("{}", logs);
     }
 }
 


### PR DESCRIPTION
This looks like a small omission - StdoutFlusher and StderrFlusher probably weren't meant to do the same. So I made StderrFlusher eprint instead of print.