### PR TITLE
Use unit structs instead of empty structs

### DIFF
--- a/src/example.rs
+++ b/src/example.rs
@@ -29,7 +29,7 @@ use crate::render::DefaultRenderer;
 
 #[derive(Debug, Default)]
 /// Flushes logs to stderr.
-pub struct StderrFlusher {}
+pub struct StderrFlusher;
 
 impl crate::Flusher for StderrFlusher {
     fn flush(&self, logs: &str) {
@@ -39,7 +39,7 @@ impl crate::Flusher for StderrFlusher {
 
 #[derive(Debug, Default)]
 /// Flushes logs to stdout.
-pub struct StdoutFlusher {}
+pub struct StdoutFlusher;
 
 impl crate::Flusher for StdoutFlusher {
     fn flush(&self, logs: &str) {

--- a/src/render.rs
+++ b/src/render.rs
@@ -82,7 +82,7 @@ use crate::Renderer;
 
 #[derive(Clone, Copy)]
 /// Renders just the `record.args()`.
-pub struct DefaultRenderer {}
+pub struct DefaultRenderer;
 
 /// The default, minimal renderer.
 pub fn default() -> &'static DefaultRenderer {
@@ -101,7 +101,7 @@ unsafe impl Sync for DefaultRenderer {}
 
 #[derive(Clone, Copy)]
 /// Renders the `record.args()`, prefixed by level, target, and file, line if they are some.
-pub struct RipgrepRenderer {}
+pub struct RipgrepRenderer;
 
 impl Renderer for RipgrepRenderer {
     fn render<'a>(&self, buf: &'a mut [u8], record: &log::Record) -> &'a [u8] {


### PR DESCRIPTION
They are easier to use, and functionality wise they are the same.  Note that this would technically be a breaking change.